### PR TITLE
Opportunity hero

### DIFF
--- a/src/Components/Hero/Hero.scss
+++ b/src/Components/Hero/Hero.scss
@@ -4,8 +4,9 @@ $opportunityThemeColor: grey;
 
 
 .hero {
-    //temp
+    // TODO - can be removed once WeatherOnMars branch has been merged (contains NavBar fix)
     margin-top: 100px;
+    //
 
     display: flex;
     flex-direction: column;

--- a/src/Components/Hero/Hero.scss
+++ b/src/Components/Hero/Hero.scss
@@ -1,12 +1,65 @@
-﻿.curiosity{
+﻿$curiosityThemeColor: grey;
+$spiritThemeColor: grey;
+$opportunityThemeColor: grey;
 
+
+.hero {
+    //temp
+    margin-top: 100px;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    h1 {
+        width: 100%;
+        text-align: center;
+        color: white;
+        font-size: 22px;
+    }
+
+    img {
+        height: auto;
+        width: 75vw;
+    }
+}
+
+
+.curiosity{
+    h1 {
+        background-color: $curiosityThemeColor;
+    }
 }
 
 .opportunity{
-
-
+    h1 {
+        background-color: $opportunityThemeColor;
+    }
 }
 
 .spirit{
+    h1 {
+        background-color: $spiritThemeColor;
+    }
+}
 
+@media (min-width: 500px){
+    .hero h1{
+        font-size: 30px;
+    }
+}
+
+@media (min-width: 768px){
+    .hero h1{
+        font-size: 40px;
+    }
+    .hero img {
+         width: 600px;
+     }
+}
+
+@media (min-width: 1024px){
+    .hero h1{
+        font-size: 55px;
+    }
 }

--- a/src/Components/Hero/Hero.scss
+++ b/src/Components/Hero/Hero.scss
@@ -1,0 +1,12 @@
+﻿.curiosity{
+
+}
+
+.opportunity{
+
+
+}
+
+.spirit{
+
+}

--- a/src/Components/Hero/Hero.tsx
+++ b/src/Components/Hero/Hero.tsx
@@ -1,5 +1,6 @@
 ﻿import React from "react";
 import {Url} from "../../Models/Url";
+import './Hero.scss';
 
 
 interface HeroProps{
@@ -9,9 +10,13 @@ interface HeroProps{
 }
 
 export function Hero(props : HeroProps){
+
+    const heroClass : string = "hero " + props.rover;
+    
     return(
         
-        <div className={props.rover}>
+        
+        <div className={heroClass}>
             <h1 className='heroTitle'>{props.headingText}</h1>
             <img className='heroImage' src={props.imageUrl}/>
         </div>

--- a/src/Components/Hero/Hero.tsx
+++ b/src/Components/Hero/Hero.tsx
@@ -1,0 +1,22 @@
+﻿import React from "react";
+import {Url} from "../../Models/Url";
+
+
+interface HeroProps{
+    headingText : 'Curiosity' | 'Spirit'  | 'Opportunity';
+    rover : 'curiosity' | 'spirit'  | 'opportunity';
+    imageUrl : Url;
+}
+
+export function Hero(props : HeroProps){
+    return(
+        
+        <div className={props.rover}>
+            <h1 className='heroTitle'>{props.headingText}</h1>
+            <img className='heroImage' src={props.imageUrl}/>
+        </div>
+        
+    );
+    
+    
+}

--- a/src/Components/Hero/Hero.tsx
+++ b/src/Components/Hero/Hero.tsx
@@ -10,17 +10,12 @@ interface HeroProps{
 }
 
 export function Hero(props : HeroProps){
-
-    const heroClass : string = "hero " + props.rover;
     
     return(
-        
-        
-        <div className={heroClass}>
+        <div className={`hero ${props.rover}`}>
             <h1 className='heroTitle'>{props.headingText}</h1>
             <img className='heroImage' src={props.imageUrl}/>
         </div>
-        
     );
     
     

--- a/src/Pages/CuriosityLandingPage/CuriosityLandingPage.tsx
+++ b/src/Pages/CuriosityLandingPage/CuriosityLandingPage.tsx
@@ -1,14 +1,12 @@
-﻿﻿import React from "react";
-import {CuriosityHero} from "../../Components/CuriosityHero/CuriosityHero";
+﻿import {Hero} from "../../Components/Hero/Hero";
 
+﻿import React from "react";
 
-const imageOfCuriosity = "https://spaceplace.nasa.gov/mars-curiosity/en/curiosity-here.en.jpg";
 
 export function Curiosity(): JSX.Element {
     return (
         <div>
-            <h2>Opportunity</h2>
-            <CuriosityHero imageUrl={imageOfCuriosity} />
+            <Hero headingText={"Curiosity"} rover={"curiosity"} imageUrl={"https://spaceplace.nasa.gov/mars-curiosity/en/curiosity-here.en.jpg"}/>
         </div>
     );
 }

--- a/src/Pages/CuriosityLandingPage/CuriosityLandingPage.tsx
+++ b/src/Pages/CuriosityLandingPage/CuriosityLandingPage.tsx
@@ -1,6 +1,6 @@
-﻿import {Hero} from "../../Components/Hero/Hero";
+﻿﻿import React from "react";
+import {Hero} from "../../Components/Hero/Hero";
 
-﻿import React from "react";
 
 
 export function Curiosity(): JSX.Element {

--- a/src/Pages/OpportunityLandingPage/OpportunityLandingPage.tsx
+++ b/src/Pages/OpportunityLandingPage/OpportunityLandingPage.tsx
@@ -1,5 +1,7 @@
 ﻿﻿import React from "react";
 import {Hero} from "../../Components/Hero/Hero";
+
+
 export function Opportunity() {
     return (
         <div>

--- a/src/Pages/OpportunityLandingPage/OpportunityLandingPage.tsx
+++ b/src/Pages/OpportunityLandingPage/OpportunityLandingPage.tsx
@@ -1,9 +1,9 @@
 ﻿﻿import React from "react";
-
+import {Hero} from "../../Components/Hero/Hero";
 export function Opportunity() {
     return (
         <div>
-            <h2>Opportunity</h2>
+            <Hero headingText={"Opportunity"} rover={"opportunity"} imageUrl={"https://spaceplace.nasa.gov/mars-curiosity/en/curiosity-here.en.jpg"}/>
         </div>
     );
 }

--- a/src/Pages/OpportunityLandingPage/OpportunityLandingPage.tsx
+++ b/src/Pages/OpportunityLandingPage/OpportunityLandingPage.tsx
@@ -3,7 +3,7 @@ import {Hero} from "../../Components/Hero/Hero";
 export function Opportunity() {
     return (
         <div>
-            <Hero headingText={"Opportunity"} rover={"opportunity"} imageUrl={"https://spaceplace.nasa.gov/mars-curiosity/en/curiosity-here.en.jpg"}/>
+            <Hero headingText={"Opportunity"} rover={"opportunity"} imageUrl={"https://video.cgtn.com/news/3d3d414e34636a4e32457a6333566d54/video/4f5e95f750a1479588d540e83524cbb6/4f5e95f750a1479588d540e83524cbb6.jpg"}/>
         </div>
     );
 }

--- a/src/Pages/SpiritLandingPage/SpiritLandingPage.tsx
+++ b/src/Pages/SpiritLandingPage/SpiritLandingPage.tsx
@@ -6,7 +6,7 @@ import {Hero} from "../../Components/Hero/Hero";
 export function Spirit() {
     return (
         <div>
-            <Hero headingText={"Spirit"} rover={"spirit"} imageUrl={"https://spaceplace.nasa.gov/mars-curiosity/en/curiosity-here.en.jpg"}/>
+            <Hero headingText={"Spirit"} rover={"spirit"} imageUrl={"https://img.itch.zone/aW1hZ2UvMTk2MTE0LzkxNjY1My5wbmc=/original/hIpl%2Bw.png"}/>
         </div>
     );
 }

--- a/src/Pages/SpiritLandingPage/SpiritLandingPage.tsx
+++ b/src/Pages/SpiritLandingPage/SpiritLandingPage.tsx
@@ -1,9 +1,12 @@
 ﻿﻿import React from "react";
+import {Hero} from "../../Components/Hero/Hero";
+
+
 
 export function Spirit() {
     return (
         <div>
-            <h2>Spirit</h2>
+            <Hero headingText={"Spirit"} rover={"spirit"} imageUrl={"https://spaceplace.nasa.gov/mars-curiosity/en/curiosity-here.en.jpg"}/>
         </div>
     );
 }


### PR DESCRIPTION
-This branch was a changed ticket for 'Generic Hero Component'
-There is now one component that can be used for all three landing page hero images/titles called 'Hero'
-styling is all currently in the Hero.scss file, constants used can be replaced when actual themes get chosen. All three theme colour constants are currently set to grey.
-I've added preliminary images to the three components on the landing pages that can be replaced at a later date. 